### PR TITLE
fix: Improve CHANGELOG date validation to check format

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clew",
   "description": "Declarative Claude Code configuration manager - like Brewfile for Homebrew. Sync plugins, marketplaces, and MCP servers across machines using a simple Clewfile.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Ada Mancini",
     "url": "https://github.com/adamancini"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-01-09
+
+### Fixed
+- CHANGELOG date validation now properly checks format (YYYY-MM-DD pattern)
+
 ## [0.4.2] - 2026-01-09
 
 ### Added

--- a/scripts/check-version-bump.sh
+++ b/scripts/check-version-bump.sh
@@ -133,8 +133,8 @@ fi
 success "Tag v$PLUGIN_VERSION does not exist yet"
 
 # Check 4: CHANGELOG must have valid date
-if [[ -z "$CHANGELOG_DATE" ]]; then
-    error "CHANGELOG.md entry for version $CHANGELOG_VERSION is missing a date"
+if [[ -z "$CHANGELOG_DATE" ]] || ! [[ "$CHANGELOG_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    error "CHANGELOG.md entry for version $CHANGELOG_VERSION is missing a valid date"
     error ""
     error "Expected format: ## [$CHANGELOG_VERSION] - YYYY-MM-DD"
     error "Fix: Add date to CHANGELOG.md entry"


### PR DESCRIPTION
## Summary

Fixes a bug in the CHANGELOG date validation discovered during comprehensive testing.

## Problem

The validation script only checked if CHANGELOG_DATE was empty, but didn't validate the date format. When the sed regex failed to match a date (e.g., when entry was '## [0.4.3]' without a date), it returned the original line instead of an empty string, causing the validation to incorrectly pass.

## Solution

Added regex pattern validation to ensure CHANGELOG_DATE matches the YYYY-MM-DD format.

## Testing

- ✅ Missing date now correctly fails with exit code 4
- ✅ Invalid date format now correctly fails
- ✅ Valid date format passes all checks
- ✅ Local validation passes

## Version Bump

Version bumped to 0.4.3 with corresponding CHANGELOG entry.