### PR TITLE
feat: local git marketplace support (v1.1.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clew",
   "description": "Declarative Claude Code configuration manager - like Brewfile for Homebrew. Sync plugins and marketplaces across machines using a simple Clewfile.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": {
     "name": "Ada Mancini",
     "url": "https://github.com/adamancini"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-16
+
+### Added
+- Local git checkout marketplaces: support `path:` in Clewfile alongside `repo:` for
+  remote marketplaces. Local path marketplaces default to `auto_update: true` (git pull
+  on every sync).
+- `ActionGitUpdate` diff action: emitted for existing local auto-update marketplaces so
+  git pull is visible in `--show-commands` output and subject to git-dirty skip logic.
+
+### Fixed
+- Export: state reader now prefers user-scope install entries over older project-scope
+  entries when both exist in `installed_plugins.json` (claude appends rather than
+  replaces on reinstall).
+- Export: orphan detection now adapts to marketplace directory layout — only checks for
+  a plugin directory when the marketplace has a standard `plugins/` subdirectory.
+  Non-standard layouts (superpowers-marketplace, yamlscript, replicated-plugins) and
+  single-plugin repos no longer produce false-positive orphan warnings.
+- Sync: plugins installed with `enabled: false` in the Clewfile are now disabled
+  immediately after installation, so a subsequent diff does not see a stale
+  enable/disable mismatch.
+
 ## [1.0.2] - 2026-03-26
 
 ### Changed

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -33,8 +33,10 @@ type ExportedClewfile struct {
 }
 
 // ExportedMarketplace represents a marketplace for export.
+// Exactly one of Repo or Path will be set.
 type ExportedMarketplace struct {
-	Repo string `json:"repo" yaml:"repo"`
+	Repo string `json:"repo,omitempty" yaml:"repo,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 	Ref  string `json:"ref,omitempty" yaml:"ref,omitempty"`
 }
 
@@ -98,28 +100,21 @@ func convertStateToClewfile(s *state.State, marketplacesDir string) *ExportedCle
 	}
 
 	// Convert marketplaces and track valid marketplace names.
-	// Skip local/directory-sourced marketplaces (empty Repo) since they
-	// cannot be represented in a portable Clewfile.
 	validMarketplaces := make(map[string]bool)
-	var skippedMarketplaces []string
 	for alias, m := range s.Marketplaces {
-		if m.Repo == "" {
-			skippedMarketplaces = append(skippedMarketplaces, alias)
-			continue
-		}
-		em := ExportedMarketplace{
-			Repo: m.Repo,
-		}
-		if m.Ref != "" {
+		em := ExportedMarketplace{}
+		switch {
+		case m.Path != "":
+			em.Path = m.Path // local directory / git checkout
+		case m.Repo != "":
+			em.Repo = m.Repo // remote repo (GitHub short form, HTTPS, SSH, or git URL)
 			em.Ref = m.Ref
+		default:
+			// No usable source — skip
+			continue
 		}
 		exported.Marketplaces[alias] = em
 		validMarketplaces[alias] = true
-	}
-	if len(skippedMarketplaces) > 0 {
-		sort.Strings(skippedMarketplaces)
-		fmt.Fprintf(os.Stderr, "Note: Skipped %d local marketplace(s) (no repo): %v\n",
-			len(skippedMarketplaces), skippedMarketplaces)
 	}
 
 	// Convert plugins, skipping those that reference non-existent marketplaces
@@ -136,8 +131,16 @@ func convertStateToClewfile(s *state.State, marketplacesDir string) *ExportedCle
 				continue // Skip this plugin - marketplace not in exported state
 			}
 
-			// Check if the plugin directory actually exists in the marketplace
-			pluginDir := filepath.Join(marketplacesDir, marketplace, "plugins", pluginName)
+			// Check if the plugin directory actually exists in the marketplace.
+			// For directory-sourced marketplaces the installLocation IS the root,
+			// so we look for plugins/ inside it; for remote marketplaces we use
+			// the standard marketplaces cache directory.
+			var pluginDir string
+			if ms, ok := s.Marketplaces[marketplace]; ok && ms.IsLocal() {
+				pluginDir = filepath.Join(ms.InstallLocation, "plugins", pluginName)
+			} else {
+				pluginDir = filepath.Join(marketplacesDir, marketplace, "plugins", pluginName)
+			}
 			if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
 				skippedOrphaned = append(skippedOrphaned, fullName)
 				continue // Skip this plugin - not found in marketplace directory

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -133,17 +133,36 @@ func convertStateToClewfile(s *state.State, marketplacesDir string) *ExportedCle
 
 			// Check if the plugin directory actually exists in the marketplace.
 			// For directory-sourced marketplaces the installLocation IS the root,
-			// so we look for plugins/ inside it; for remote marketplaces we use
-			// the standard marketplaces cache directory.
-			var pluginDir string
+			// so we look for plugins/ inside it.
+			// For remote marketplaces we only check if the marketplace has a standard
+			// plugins/ subdirectory layout — not all marketplaces follow this convention
+			// (e.g. superpowers-marketplace, yamlscript, replicated-plugins use their own
+			// layouts). If no plugins/ dir is present, skip the check and trust the install
+			// registry.
 			if ms, ok := s.Marketplaces[marketplace]; ok && ms.IsLocal() {
-				pluginDir = filepath.Join(ms.InstallLocation, "plugins", pluginName)
+				// Local marketplace: only check if a plugins/ subdirectory exists.
+				// Some local marketplaces are single-plugin repos (the repo IS the plugin),
+				// which have no plugins/ dir. In that case trust the install registry.
+				localPluginsDir := filepath.Join(ms.InstallLocation, "plugins")
+				if info, err := os.Stat(localPluginsDir); err == nil && info.IsDir() {
+					pluginDir := filepath.Join(localPluginsDir, pluginName)
+					if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+						skippedOrphaned = append(skippedOrphaned, fullName)
+						continue // Skip this plugin - not found in marketplace directory
+					}
+				}
+				// No plugins/ dir — single-plugin repo; trust installed_plugins.json.
 			} else {
-				pluginDir = filepath.Join(marketplacesDir, marketplace, "plugins", pluginName)
-			}
-			if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-				skippedOrphaned = append(skippedOrphaned, fullName)
-				continue // Skip this plugin - not found in marketplace directory
+				marketplacePluginsDir := filepath.Join(marketplacesDir, marketplace, "plugins")
+				if info, err := os.Stat(marketplacePluginsDir); err == nil && info.IsDir() {
+					// Marketplace has a standard plugins/ layout — check for the plugin.
+					pluginDir := filepath.Join(marketplacePluginsDir, pluginName)
+					if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+						skippedOrphaned = append(skippedOrphaned, fullName)
+						continue // Skip this plugin - not found in marketplace directory
+					}
+				}
+				// No plugins/ dir — non-standard layout; trust installed_plugins.json.
 			}
 		}
 

--- a/internal/cmd/export_test.go
+++ b/internal/cmd/export_test.go
@@ -240,14 +240,16 @@ func TestConvertStateToClewfile_MixedPlugins(t *testing.T) {
 }
 
 func TestConvertStateToClewfile_LocalMarketplaceSkipStillWorks(t *testing.T) {
-	// Ensure the existing local marketplace skip logic still works
+	// A marketplace with neither Repo nor Path is unusable — it should be
+	// silently excluded from export.  Its plugins are skipped too (they reference
+	// a marketplace that did not make it into the exported map).
 	marketplacesDir := setupMarketplaceDir(t, map[string][]string{})
 
 	s := &state.State{
 		Marketplaces: map[string]state.MarketplaceState{
-			"local-marketplace": {
-				Alias: "local-marketplace",
-				Repo:  "", // Local marketplace has no repo
+			"unusable": {
+				Alias: "unusable",
+				// Both Repo and Path are empty — nothing to add.
 			},
 			"remote-marketplace": {
 				Alias: "remote-marketplace",
@@ -255,9 +257,9 @@ func TestConvertStateToClewfile_LocalMarketplaceSkipStillWorks(t *testing.T) {
 			},
 		},
 		Plugins: map[string]state.PluginState{
-			"local-plugin@local-marketplace": {
+			"local-plugin@unusable": {
 				Name:        "local-plugin",
-				Marketplace: "local-marketplace",
+				Marketplace: "unusable",
 				Scope:       "user",
 				Enabled:     true,
 			},
@@ -267,9 +269,9 @@ func TestConvertStateToClewfile_LocalMarketplaceSkipStillWorks(t *testing.T) {
 	stderr := captureStderr(t, func() {
 		exported := convertStateToClewfile(s, marketplacesDir)
 
-		// Local marketplace should not be exported
-		if _, ok := exported.Marketplaces["local-marketplace"]; ok {
-			t.Error("local marketplace should not be exported")
+		// Unusable marketplace should not be exported
+		if _, ok := exported.Marketplaces["unusable"]; ok {
+			t.Error("unusable marketplace should not be exported")
 		}
 
 		// Remote marketplace should be exported
@@ -277,20 +279,56 @@ func TestConvertStateToClewfile_LocalMarketplaceSkipStillWorks(t *testing.T) {
 			t.Error("remote marketplace should be exported")
 		}
 
-		// Plugin referencing local marketplace should be skipped
+		// Plugin referencing the unusable marketplace should be skipped
 		if len(exported.Plugins) != 0 {
-			t.Fatalf("expected 0 plugins (local plugin should be skipped), got %d", len(exported.Plugins))
+			t.Fatalf("expected 0 plugins, got %d", len(exported.Plugins))
 		}
 	})
 
-	// Should see local marketplace skip message
-	if !strings.Contains(stderr, "local marketplace") {
-		t.Errorf("expected local marketplace warning in stderr, got: %s", stderr)
-	}
-	// Should see non-marketplace plugin skip message
+	// Plugin is skipped because its marketplace wasn't exported
 	if !strings.Contains(stderr, "referencing non-marketplace sources") {
 		t.Errorf("expected non-marketplace sources warning in stderr, got: %s", stderr)
 	}
+}
+
+func TestConvertStateToClewfile_DirectoryMarketplaceExported(t *testing.T) {
+	// A marketplace with a local path should be exported with path: instead of repo:
+	marketplacesDir := setupMarketplaceDir(t, map[string][]string{
+		"local-mkt": {"my-plugin"},
+	})
+
+	s := &state.State{
+		Marketplaces: map[string]state.MarketplaceState{
+			"local-mkt": {
+				Alias:           "local-mkt",
+				Path:            "/tmp/local-mkt",
+				InstallLocation: filepath.Join(marketplacesDir, "local-mkt"),
+			},
+		},
+		Plugins: map[string]state.PluginState{
+			"my-plugin@local-mkt": {
+				Name:        "my-plugin",
+				Marketplace: "local-mkt",
+				Scope:       "user",
+				Enabled:     true,
+			},
+		},
+	}
+
+	captureStderr(t, func() {
+		exported := convertStateToClewfile(s, marketplacesDir)
+
+		em, ok := exported.Marketplaces["local-mkt"]
+		if !ok {
+			t.Fatal("local-mkt marketplace should be exported")
+		}
+		if em.Path != "/tmp/local-mkt" {
+			t.Errorf("Path = %q, want /tmp/local-mkt", em.Path)
+		}
+		if em.Repo != "" {
+			t.Errorf("Repo should be empty for directory marketplace, got %q", em.Repo)
+		}
+	})
 }
 
 func TestConvertStateToClewfile_PluginWithoutMarketplace(t *testing.T) {

--- a/internal/cmd/sync_integration_test.go
+++ b/internal/cmd/sync_integration_test.go
@@ -501,6 +501,10 @@ func (r *testCommandRunner) Run(name string, args ...string) ([]byte, error) {
 	return r.runFunc(name, args...)
 }
 
+func (r *testCommandRunner) RunInDir(dir, name string, args ...string) ([]byte, error) {
+	return r.runFunc(name, args...)
+}
+
 // TestIntegration_BackupCreation tests backup functionality.
 func TestIntegration_BackupCreation(t *testing.T) {
 	ts := newTestSetup(t)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,47 @@ const (
 
 // Marketplace represents a plugin marketplace source.
 // Marketplaces are repositories containing multiple plugins that can be installed.
+// Exactly one of Repo (remote) or Path (local git checkout) must be set.
 type Marketplace struct {
-	Repo string `yaml:"repo" toml:"repo" json:"repo"` // Repository URL (e.g., "owner/repo", "https://gitlab.com/company/plugins.git")
-	Ref  string `yaml:"ref,omitempty" toml:"ref,omitempty" json:"ref,omitempty"` // Optional git ref (branch/tag/SHA)
+	Repo       string `yaml:"repo,omitempty" toml:"repo,omitempty" json:"repo,omitempty"`                           // Remote repo URL (e.g., "owner/repo", "https://gitlab.com/company/plugins.git")
+	Path       string `yaml:"path,omitempty" toml:"path,omitempty" json:"path,omitempty"`                           // Local git repo path (e.g., "~/plugins/my-tools")
+	Ref        string `yaml:"ref,omitempty" toml:"ref,omitempty" json:"ref,omitempty"`                               // Optional git ref (branch/tag/SHA) — remote repos only
+	AutoUpdate *bool  `yaml:"auto_update,omitempty" toml:"auto_update,omitempty" json:"auto_update,omitempty"` // Auto git-pull before sync (default true for local paths)
+}
+
+// IsLocal returns true when this marketplace is a local git checkout.
+func (m Marketplace) IsLocal() bool {
+	return m.Path != ""
+}
+
+// IsAutoUpdate returns true when the marketplace should be git-pulled on each sync.
+// Defaults to true for local paths, false for remote repos.
+func (m Marketplace) IsAutoUpdate() bool {
+	if m.AutoUpdate != nil {
+		return *m.AutoUpdate
+	}
+	return m.IsLocal()
+}
+
+// Source returns the argument passed to `claude plugin marketplace add`.
+// For remote repos this is the repo URL; for local paths it is the expanded absolute path.
+func (m Marketplace) Source() string {
+	if m.IsLocal() {
+		return expandPath(m.Path)
+	}
+	return m.Repo
+}
+
+// expandPath expands a leading ~/ to the user's home directory.
+func expandPath(path string) string {
+	if len(path) >= 2 && path[:2] == "~/" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
 }
 
 // Clewfile represents the parsed configuration file.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -10,7 +10,8 @@
 //  4. See CLAUDE.md "Schema Maintenance" section for full checklist
 //
 // Synced validation rules:
-//   - Marketplace repo: non-empty string (validateMarketplaces)
+//   - Marketplace sources: exactly one of repo or path (validateMarketplaces)
+//   - Marketplace repo/path: non-empty string (validateMarketplaces)
 //   - Plugin scopes: user only (validatePlugin)
 //   - Plugin name format: plugin@marketplace (validatePluginReferences)
 package config
@@ -74,15 +75,29 @@ func validateMarketplaces(marketplaces map[string]Marketplace) error {
 			}
 		}
 
-		// Validate repo is required and non-empty
-		if m.Repo == "" {
+		// Exactly one of repo or path must be set
+		hasRepo := m.Repo != ""
+		hasPath := m.Path != ""
+		if !hasRepo && !hasPath {
 			return ValidationError{
-				Field:   fmt.Sprintf("marketplaces.%s.repo", alias),
-				Message: "repo is required",
+				Field:   fmt.Sprintf("marketplaces.%s", alias),
+				Message: "either repo (remote) or path (local git checkout) is required",
+			}
+		}
+		if hasRepo && hasPath {
+			return ValidationError{
+				Field:   fmt.Sprintf("marketplaces.%s", alias),
+				Message: "repo and path are mutually exclusive — use repo for remote or path for local",
 			}
 		}
 
-		// Note: ref is optional, git will validate if it exists
+		// ref only makes sense for remote repos
+		if hasPath && m.Ref != "" {
+			return ValidationError{
+				Field:   fmt.Sprintf("marketplaces.%s.ref", alias),
+				Message: "ref is not supported for local path marketplaces",
+			}
+		}
 	}
 
 	return nil

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -41,12 +41,35 @@ func TestValidateMarketplaces(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "missing repo",
+			name: "missing repo and path",
 			marketplaces: map[string]Marketplace{
 				"bad": {},
 			},
 			wantErr:     true,
-			errContains: "repo is required",
+			errContains: "either repo (remote) or path (local git checkout) is required",
+		},
+		{
+			name: "repo and path both set",
+			marketplaces: map[string]Marketplace{
+				"bad": {Repo: "org/repo", Path: "~/plugins/repo"},
+			},
+			wantErr:     true,
+			errContains: "mutually exclusive",
+		},
+		{
+			name: "valid local path marketplace",
+			marketplaces: map[string]Marketplace{
+				"local": {Path: "~/plugins/my-tools"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ref not allowed for local path",
+			marketplaces: map[string]Marketplace{
+				"bad": {Path: "~/plugins/my-tools", Ref: "main"},
+			},
+			wantErr:     true,
+			errContains: "ref is not supported for local path",
 		},
 		{
 			name:         "empty marketplaces map is valid",

--- a/internal/diff/commands.go
+++ b/internal/diff/commands.go
@@ -16,14 +16,30 @@ type Command struct {
 func (r *Result) GenerateCommands() []Command {
 	var commands []Command
 
-	// 1. Add marketplaces first (plugins depend on them)
+	// 1. Add / update marketplaces first (plugins depend on them)
 	for _, m := range r.Marketplaces {
-		if m.Action == ActionAdd && m.Desired != nil {
-			cmd := fmt.Sprintf("claude plugin marketplace add %s", m.Desired.Repo)
-			commands = append(commands, Command{
-				Command:     cmd,
-				Description: fmt.Sprintf("Add marketplace: %s", m.Alias),
-			})
+		switch m.Action {
+		case ActionAdd:
+			if m.Desired != nil {
+				// For local paths, git pull before registering (in case it already exists on disk)
+				if m.Desired.IsLocal() {
+					commands = append(commands, Command{
+						Command:     fmt.Sprintf("git -C %s pull", m.Desired.Source()),
+						Description: fmt.Sprintf("Pull latest changes for local marketplace: %s", m.Alias),
+					})
+				}
+				commands = append(commands, Command{
+					Command:     fmt.Sprintf("claude plugin marketplace add %s", m.Desired.Source()),
+					Description: fmt.Sprintf("Add marketplace: %s", m.Alias),
+				})
+			}
+		case ActionGitUpdate:
+			if m.Desired != nil {
+				commands = append(commands, Command{
+					Command:     fmt.Sprintf("git -C %s pull", m.Desired.Source()),
+					Description: fmt.Sprintf("Pull latest changes for local marketplace: %s", m.Alias),
+				})
+			}
 		}
 	}
 

--- a/internal/diff/compute.go
+++ b/internal/diff/compute.go
@@ -26,11 +26,19 @@ func computeMarketplaceDiffs(desired map[string]config.Marketplace, current map[
 
 		if c, exists := current[alias]; exists {
 			currentCopy := c
-			// Check if update needed (repo or ref changed)
+			// Check if configuration update needed (source changed)
 			if marketplaceNeedsUpdate(d, c) {
 				diffs = append(diffs, MarketplaceDiff{
 					Alias:   alias,
 					Action:  ActionUpdate,
+					Current: &currentCopy,
+					Desired: &desiredCopy,
+				})
+			} else if d.IsLocal() && d.IsAutoUpdate() {
+				// Local git marketplace that is already registered — pull on every sync.
+				diffs = append(diffs, MarketplaceDiff{
+					Alias:   alias,
+					Action:  ActionGitUpdate,
 					Current: &currentCopy,
 					Desired: &desiredCopy,
 				})
@@ -68,11 +76,14 @@ func computeMarketplaceDiffs(desired map[string]config.Marketplace, current map[
 }
 
 func marketplaceNeedsUpdate(desired config.Marketplace, current state.MarketplaceState) bool {
-	// Check if repo changed
+	if desired.IsLocal() {
+		// Local marketplace: compare expanded paths
+		return desired.Source() != current.Path
+	}
+	// Remote marketplace: compare repo URL and ref
 	if desired.Repo != current.Repo {
 		return true
 	}
-	// Check if ref changed
 	if desired.Ref != current.Ref {
 		return true
 	}

--- a/internal/diff/compute_test.go
+++ b/internal/diff/compute_test.go
@@ -55,6 +55,81 @@ func TestComputeMarketplaces(t *testing.T) {
 	}
 }
 
+func TestComputeLocalGitMarketplace(t *testing.T) {
+	autoTrue := true
+
+	t.Run("new local marketplace gets ActionAdd", func(t *testing.T) {
+		clewfile := &config.Clewfile{
+			Marketplaces: map[string]config.Marketplace{
+				"local-tools": {Path: "/tmp/local-tools"},
+			},
+		}
+		current := &state.State{
+			Marketplaces: make(map[string]state.MarketplaceState),
+			Plugins:      make(map[string]state.PluginState),
+		}
+		result := Compute(clewfile, current)
+		if len(result.Marketplaces) != 1 || result.Marketplaces[0].Action != ActionAdd {
+			t.Errorf("expected ActionAdd for new local marketplace, got %+v", result.Marketplaces)
+		}
+	})
+
+	t.Run("existing local marketplace with auto_update gets ActionGitUpdate", func(t *testing.T) {
+		clewfile := &config.Clewfile{
+			Marketplaces: map[string]config.Marketplace{
+				"local-tools": {Path: "/tmp/local-tools", AutoUpdate: &autoTrue},
+			},
+		}
+		current := &state.State{
+			Marketplaces: map[string]state.MarketplaceState{
+				"local-tools": {Alias: "local-tools", Path: "/tmp/local-tools"},
+			},
+			Plugins: make(map[string]state.PluginState),
+		}
+		result := Compute(clewfile, current)
+		if len(result.Marketplaces) != 1 || result.Marketplaces[0].Action != ActionGitUpdate {
+			t.Errorf("expected ActionGitUpdate for existing local auto-update marketplace, got %+v", result.Marketplaces)
+		}
+	})
+
+	t.Run("existing local marketplace with auto_update default true gets ActionGitUpdate", func(t *testing.T) {
+		// auto_update defaults to true for local paths
+		clewfile := &config.Clewfile{
+			Marketplaces: map[string]config.Marketplace{
+				"local-tools": {Path: "/tmp/local-tools"},
+			},
+		}
+		current := &state.State{
+			Marketplaces: map[string]state.MarketplaceState{
+				"local-tools": {Alias: "local-tools", Path: "/tmp/local-tools"},
+			},
+			Plugins: make(map[string]state.PluginState),
+		}
+		result := Compute(clewfile, current)
+		if len(result.Marketplaces) != 1 || result.Marketplaces[0].Action != ActionGitUpdate {
+			t.Errorf("expected ActionGitUpdate (default auto_update=true), got %+v", result.Marketplaces)
+		}
+	})
+
+	t.Run("path changed gets ActionUpdate", func(t *testing.T) {
+		clewfile := &config.Clewfile{
+			Marketplaces: map[string]config.Marketplace{
+				"local-tools": {Path: "/tmp/new-path"},
+			},
+		}
+		current := &state.State{
+			Marketplaces: map[string]state.MarketplaceState{
+				"local-tools": {Alias: "local-tools", Path: "/tmp/old-path"},
+			},
+			Plugins: make(map[string]state.PluginState),
+		}
+		result := Compute(clewfile, current)
+		if len(result.Marketplaces) != 1 || result.Marketplaces[0].Action != ActionUpdate {
+			t.Errorf("expected ActionUpdate when path changed, got %+v", result.Marketplaces)
+		}
+	})
+}
+
 func TestComputePlugins(t *testing.T) {
 	clewfile := &config.Clewfile{
 		Plugins: []config.Plugin{

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -10,13 +10,14 @@ import (
 type Action string
 
 const (
-	ActionNone    Action = "none"     // Already in desired state
-	ActionAdd     Action = "add"      // Needs to be added
-	ActionRemove  Action = "remove"   // Exists but not in Clewfile (info only)
-	ActionUpdate  Action = "update"   // Needs configuration update
-	ActionEnable  Action = "enable"   // Needs to be enabled
-	ActionDisable Action = "disable"  // Needs to be disabled
-	ActionSkipGit Action = "skip_git" // Skipped due to git status issues
+	ActionNone      Action = "none"       // Already in desired state
+	ActionAdd       Action = "add"        // Needs to be added
+	ActionRemove    Action = "remove"     // Exists but not in Clewfile (info only)
+	ActionUpdate    Action = "update"     // Needs configuration update
+	ActionEnable    Action = "enable"     // Needs to be enabled
+	ActionDisable   Action = "disable"    // Needs to be disabled
+	ActionSkipGit   Action = "skip_git"   // Skipped due to git status issues
+	ActionGitUpdate Action = "git_update" // Pull latest changes for a local git marketplace
 )
 
 // MarketplaceDiff represents the diff for a marketplace.
@@ -52,7 +53,7 @@ func (r *Result) Summary() (add, update, remove, attention int) {
 		switch m.Action {
 		case ActionAdd:
 			add++
-		case ActionUpdate:
+		case ActionUpdate, ActionGitUpdate:
 			update++
 		case ActionRemove, ActionSkipGit:
 			attention++

--- a/internal/git/checker.go
+++ b/internal/git/checker.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"fmt"
+
 	"github.com/adamancini/clew/internal/config"
 )
 
@@ -44,7 +46,8 @@ func (r *CheckResult) HasInfo() bool {
 	return len(r.Info) > 0
 }
 
-// CheckClewfile checks git status for all local marketplaces and plugins in the Clewfile.
+// CheckClewfile checks git status for all local path-based marketplaces in the Clewfile.
+// Remote repo marketplaces are skipped since they are managed by the claude CLI.
 func (c *Checker) CheckClewfile(clewfile *config.Clewfile) *CheckResult {
 	result := NewCheckResult()
 
@@ -54,9 +57,25 @@ func (c *Checker) CheckClewfile(clewfile *config.Clewfile) *CheckResult {
 		return result
 	}
 
-	// Local sources are no longer supported (removed in v0.7.0)
-	// Git status checking only applies to github sources, which are
-	// not stored locally and thus don't need git status checks.
+	for alias, m := range clewfile.Marketplaces {
+		if !m.IsLocal() {
+			continue
+		}
+		status := c.CheckRepository(m.Path)
+		result.Marketplaces[alias] = status
+		switch status.Level {
+		case LevelWarning:
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("marketplace %q has uncommitted changes (%s) - skipping git pull", alias, m.Path))
+			result.SkipMarketplaces[alias] = true
+		case LevelError:
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("marketplace %q git check failed: %v - skipping git pull", alias, status.Error))
+			result.SkipMarketplaces[alias] = true
+		case LevelInfo:
+			result.Info = append(result.Info, fmt.Sprintf("marketplace %q: %s", alias, status.Message))
+		}
+	}
 
 	return result
 }

--- a/internal/state/fs_reader.go
+++ b/internal/state/fs_reader.go
@@ -97,6 +97,7 @@ func (r *FilesystemReader) readMarketplaces(claudeDir string, state *State) erro
 		state.Marketplaces[alias] = MarketplaceState{
 			Alias:           alias,
 			Repo:            m.Source.Repo,
+			Path:            m.Source.Path,
 			InstallLocation: m.InstallLocation,
 			LastUpdated:     m.LastUpdated,
 		}

--- a/internal/state/fs_reader.go
+++ b/internal/state/fs_reader.go
@@ -150,9 +150,17 @@ func (r *FilesystemReader) readPlugins(claudeDir string, state *State) error {
 			marketplace = parts[1]
 		}
 
-		// Use the first (most recent) install for each plugin
+		// Prefer user-scope install; fall back to first entry.
+		// Claude appends new installs rather than replacing existing ones, so a plugin
+		// reinstalled at user scope may appear after an older project-scope entry.
 		if len(installs) > 0 {
 			install := installs[0]
+			for _, candidate := range installs {
+				if candidate.Scope == "user" {
+					install = candidate
+					break
+				}
+			}
 
 			// Detect if this is a local plugin:
 			// 1. If installPath is in the repos/ directory, OR

--- a/internal/state/fs_reader.go
+++ b/internal/state/fs_reader.go
@@ -10,11 +10,17 @@ import (
 )
 
 // fsMarketplaceEntry represents a single marketplace in known_marketplaces.json.
+// The claude CLI uses several source types:
+//   - "github"    — GitHub short form (owner/repo) or HTTPS URL; Repo field holds the value
+//   - "directory" — Local filesystem path; Path field holds the value
+//   - "git"       — Arbitrary git remote URL; URL field holds the value
+//   - "local"     — Legacy alias for "directory"
 type fsMarketplaceEntry struct {
 	Source struct {
-		Source string `json:"source"` // "github" or "local"
+		Source string `json:"source"` // "github", "directory", "git", or "local"
 		Repo   string `json:"repo,omitempty"`
 		Path   string `json:"path,omitempty"`
+		URL    string `json:"url,omitempty"` // used by "git" source type
 	} `json:"source"`
 	InstallLocation string `json:"installLocation"`
 	LastUpdated     string `json:"lastUpdated"`
@@ -94,13 +100,25 @@ func (r *FilesystemReader) readMarketplaces(claudeDir string, state *State) erro
 	}
 
 	for alias, m := range marketplaces {
-		state.Marketplaces[alias] = MarketplaceState{
+		ms := MarketplaceState{
 			Alias:           alias,
-			Repo:            m.Source.Repo,
-			Path:            m.Source.Path,
 			InstallLocation: m.InstallLocation,
 			LastUpdated:     m.LastUpdated,
 		}
+		switch m.Source.Source {
+		case "github":
+			ms.Repo = m.Source.Repo
+		case "directory", "local":
+			ms.Path = m.Source.Path
+		case "git":
+			// Treat git URL sources as a remote repo (URL is valid as repo value)
+			ms.Repo = m.Source.URL
+		default:
+			// Unknown source type: preserve whatever is available
+			ms.Repo = m.Source.Repo
+			ms.Path = m.Source.Path
+		}
+		state.Marketplaces[alias] = ms
 	}
 
 	return nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,10 +10,16 @@ type State struct {
 // MarketplaceState represents a marketplace's current state.
 type MarketplaceState struct {
 	Alias           string // Short name used for referencing
-	Repo            string // Repository URL (e.g., "owner/repo")
+	Repo            string // Remote repository URL (e.g., "owner/repo") — empty for local
+	Path            string // Local git checkout path — empty for remote
 	Ref             string // Git ref (branch/tag/SHA) if specified
 	InstallLocation string // Local path where marketplace is cloned
 	LastUpdated     string // Last update timestamp
+}
+
+// IsLocal returns true when this marketplace is a local git checkout.
+func (m MarketplaceState) IsLocal() bool {
+	return m.Path != ""
 }
 
 // PluginState represents a plugin's current state.

--- a/internal/sync/executor.go
+++ b/internal/sync/executor.go
@@ -120,6 +120,18 @@ func (s *Syncer) installPlugin(p diff.PluginDiff) (Operation, error) {
 		return op, fmt.Errorf("failed to install plugin %s: %w\nOutput: %s", p.Name, err, string(output))
 	}
 
+	// Plugins are installed enabled by default. If the desired state is disabled,
+	// run a follow-up disable so the install and disable are atomic from clew's perspective.
+	if p.Desired != nil && p.Desired.Enabled != nil && !*p.Desired.Enabled {
+		disableOutput, disableErr := s.runner.Run("claude", "plugin", "disable", p.Desired.Name)
+		if disableErr != nil {
+			op.Success = false
+			op.Error = fmt.Sprintf("installed plugin %s but failed to disable it: %v\nOutput: %s", p.Name, disableErr, string(disableOutput))
+			return op, fmt.Errorf("installed plugin %s but failed to disable it: %w", p.Name, disableErr)
+		}
+		op.Command += fmt.Sprintf(" && claude plugin disable %s", p.Desired.Name)
+	}
+
 	op.Success = true
 	return op, nil
 }

--- a/internal/sync/executor.go
+++ b/internal/sync/executor.go
@@ -13,6 +13,7 @@ import (
 // This allows for mocking in tests.
 type CommandRunner interface {
 	Run(name string, args ...string) ([]byte, error)
+	RunInDir(dir, name string, args ...string) ([]byte, error)
 }
 
 // DefaultCommandRunner uses os/exec to run commands.
@@ -23,7 +24,14 @@ func (r *DefaultCommandRunner) Run(name string, args ...string) ([]byte, error) 
 	return cmd.CombinedOutput()
 }
 
-// addMarketplace executes `claude plugin marketplace add <repo>`.
+func (r *DefaultCommandRunner) RunInDir(dir, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
+// addMarketplace executes `claude plugin marketplace add <source>`.
+// Source is the repo URL for remote marketplaces or the local path for git checkouts.
 func (s *Syncer) addMarketplace(m diff.MarketplaceDiff) (Operation, error) {
 	op := Operation{
 		Type:   "marketplace",
@@ -37,16 +45,45 @@ func (s *Syncer) addMarketplace(m diff.MarketplaceDiff) (Operation, error) {
 		return op, fmt.Errorf("no desired state for marketplace %s", m.Alias)
 	}
 
-	op.Description = fmt.Sprintf("Add marketplace: %s (%s)", m.Alias, m.Desired.Repo)
+	source := m.Desired.Source()
+	op.Description = fmt.Sprintf("Add marketplace: %s (%s)", m.Alias, source)
+	op.Command = fmt.Sprintf("claude plugin marketplace add %s", source)
 
-	// Build command string before executing
-	op.Command = fmt.Sprintf("claude plugin marketplace add %s", m.Desired.Repo)
-
-	output, err := s.runner.Run("claude", "plugin", "marketplace", "add", m.Desired.Repo)
+	output, err := s.runner.Run("claude", "plugin", "marketplace", "add", source)
 	if err != nil {
 		op.Success = false
 		op.Error = fmt.Sprintf("failed to add marketplace %s: %v\nOutput: %s", m.Alias, err, string(output))
 		return op, fmt.Errorf("failed to add marketplace %s: %w\nOutput: %s", m.Alias, err, string(output))
+	}
+
+	op.Success = true
+	return op, nil
+}
+
+// gitPullMarketplace runs `git pull` inside the local marketplace checkout.
+// It is used for ActionGitUpdate — local marketplaces with auto_update: true.
+func (s *Syncer) gitPullMarketplace(m diff.MarketplaceDiff) (Operation, error) {
+	op := Operation{
+		Type:   "marketplace",
+		Name:   m.Alias,
+		Action: "git_update",
+	}
+
+	if m.Desired == nil {
+		op.Success = false
+		op.Error = fmt.Sprintf("no desired state for marketplace %s", m.Alias)
+		return op, fmt.Errorf("no desired state for marketplace %s", m.Alias)
+	}
+
+	path := m.Desired.Source()
+	op.Description = fmt.Sprintf("Pull latest changes for local marketplace: %s (%s)", m.Alias, path)
+	op.Command = fmt.Sprintf("git -C %s pull", path)
+
+	output, err := s.runner.RunInDir(path, "git", "pull")
+	if err != nil {
+		op.Success = false
+		op.Error = fmt.Sprintf("git pull failed for marketplace %s (%s): %v\nOutput: %s", m.Alias, path, err, string(output))
+		return op, fmt.Errorf("git pull failed for marketplace %s: %w\nOutput: %s", m.Alias, err, string(output))
 	}
 
 	op.Success = true

--- a/internal/sync/executor_test.go
+++ b/internal/sync/executor_test.go
@@ -31,6 +31,19 @@ func (m *MockCommandRunner) Run(name string, args ...string) ([]byte, error) {
 	return []byte("success"), nil
 }
 
+func (m *MockCommandRunner) RunInDir(dir, name string, args ...string) ([]byte, error) {
+	cmd := name + " " + strings.Join(args, " ")
+	m.Commands = append(m.Commands, cmd)
+
+	if err, ok := m.Errors[cmd]; ok {
+		return nil, err
+	}
+	if output, ok := m.Outputs[cmd]; ok {
+		return output, nil
+	}
+	return []byte("Already up to date."), nil
+}
+
 func newMockSyncer() (*Syncer, *MockCommandRunner) {
 	mock := &MockCommandRunner{
 		Commands: []string{},
@@ -38,6 +51,89 @@ func newMockSyncer() (*Syncer, *MockCommandRunner) {
 		Errors:   make(map[string]error),
 	}
 	return NewSyncerWithRunner(mock), mock
+}
+
+func TestAddLocalPathMarketplace(t *testing.T) {
+	syncer, mock := newMockSyncer()
+
+	m := diff.MarketplaceDiff{
+		Alias:  "local-tools",
+		Action: diff.ActionAdd,
+		Desired: &config.Marketplace{
+			Path: "/tmp/local-tools",
+		},
+	}
+
+	op, err := syncer.addMarketplace(m)
+	if err != nil {
+		t.Fatalf("addMarketplace() error = %v", err)
+	}
+
+	expected := "claude plugin marketplace add /tmp/local-tools"
+	if len(mock.Commands) != 1 || mock.Commands[0] != expected {
+		t.Errorf("Command = %v, want [%q]", mock.Commands, expected)
+	}
+	if op.Command != expected {
+		t.Errorf("Operation.Command = %q, want %q", op.Command, expected)
+	}
+	if !op.Success {
+		t.Errorf("Operation.Success = %v, want true", op.Success)
+	}
+}
+
+func TestGitPullMarketplace(t *testing.T) {
+	syncer, mock := newMockSyncer()
+
+	m := diff.MarketplaceDiff{
+		Alias:  "local-tools",
+		Action: diff.ActionGitUpdate,
+		Desired: &config.Marketplace{
+			Path: "/tmp/local-tools",
+		},
+	}
+
+	op, err := syncer.gitPullMarketplace(m)
+	if err != nil {
+		t.Fatalf("gitPullMarketplace() error = %v", err)
+	}
+
+	if len(mock.Commands) != 1 || mock.Commands[0] != "git pull" {
+		t.Errorf("Commands = %v, want [\"git pull\"]", mock.Commands)
+	}
+	if op.Action != "git_update" {
+		t.Errorf("Operation.Action = %q, want %q", op.Action, "git_update")
+	}
+	if !op.Success {
+		t.Errorf("Operation.Success = %v, want true", op.Success)
+	}
+}
+
+func TestExecuteGitUpdate(t *testing.T) {
+	syncer, _ := newMockSyncer()
+
+	d := &diff.Result{
+		Marketplaces: []diff.MarketplaceDiff{
+			{
+				Alias:  "local-tools",
+				Action: diff.ActionGitUpdate,
+				Desired: &config.Marketplace{
+					Path: "/tmp/local-tools",
+				},
+			},
+		},
+		Plugins: []diff.PluginDiff{},
+	}
+
+	result, err := syncer.Execute(d, Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", result.Updated)
+	}
+	if result.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", result.Failed)
+	}
 }
 
 func TestAddMarketplace(t *testing.T) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -113,6 +113,15 @@ func (s *Syncer) Execute(d *diff.Result, opts Options) (*Result, error) {
 			} else {
 				result.Installed++
 			}
+		case diff.ActionGitUpdate:
+			op, err := s.gitPullMarketplace(m)
+			result.Operations = append(result.Operations, op)
+			if err != nil {
+				result.Failed++
+				result.Errors = append(result.Errors, err)
+			} else {
+				result.Updated++
+			}
 		case diff.ActionRemove:
 			// Info only - don't remove
 			result.Attention = append(result.Attention, "marketplace: "+m.Alias)

--- a/schema/clewfile.schema.json
+++ b/schema/clewfile.schema.json
@@ -14,24 +14,49 @@
     },
     "marketplaces": {
       "type": "object",
-      "description": "Plugin marketplace repositories",
+      "description": "Plugin marketplace repositories. Each entry uses either repo (remote) or path (local git checkout), not both.",
       "additionalProperties": {
         "type": "object",
-        "required": ["repo"],
-        "properties": {
-          "repo": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Repository URL - short form (owner/repo), HTTPS, or SSH",
-            "examples": ["anthropics/claude-plugins-official", "https://github.com/obra/superpowers-marketplace.git", "git@github.com:owner/repo.git"]
+        "oneOf": [
+          {
+            "required": ["repo"],
+            "properties": {
+              "repo": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Remote repository URL — short form (owner/repo), HTTPS, or SSH",
+                "examples": ["anthropics/claude-plugins-official", "https://github.com/obra/superpowers-marketplace.git", "git@github.com:owner/repo.git"]
+              },
+              "ref": {
+                "type": "string",
+                "description": "Optional git ref (branch, tag, or SHA) — remote repos only",
+                "examples": ["main", "v1.0.0", "abc1234"]
+              },
+              "auto_update": {
+                "type": "boolean",
+                "description": "Whether to git-pull before syncing (default false for remote repos)"
+              }
+            },
+            "additionalProperties": false
           },
-          "ref": {
-            "type": "string",
-            "description": "Optional git ref (branch, tag, or SHA)",
-            "examples": ["main", "v1.0.0", "abc1234"]
+          {
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Absolute or ~-prefixed path to a local git checkout of the marketplace",
+                "examples": ["~/plugins/devops-toolkit", "/Users/ada/.claude/plugins/repos/my-tools"]
+              },
+              "auto_update": {
+                "type": "boolean",
+                "description": "Whether to git-pull before syncing (default true for local paths)",
+                "default": true
+              }
+            },
+            "additionalProperties": false
           }
-        },
-        "additionalProperties": false
+        ]
       },
       "examples": [
         {
@@ -41,6 +66,10 @@
           "superpowers-marketplace": {
             "repo": "obra/superpowers-marketplace",
             "ref": "main"
+          },
+          "devops-toolkit": {
+            "path": "~/.claude/plugins/repos/devops-toolkit",
+            "auto_update": true
           }
         }
       ]

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -432,8 +432,8 @@ func TestValidation(t *testing.T) {
 			t.Fatal("expected command to fail with missing repo")
 		}
 
-		if !strings.Contains(stderr, "repo is required") {
-			t.Errorf("expected validation error message about missing repo, got: %s", stderr)
+		if !strings.Contains(stderr, "either repo") && !strings.Contains(stderr, "repo is required") {
+			t.Errorf("expected validation error message about missing repo or path, got: %s", stderr)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Add `path:` support in Clewfile for local git checkout marketplaces (alongside existing `repo:` for remotes). Local path marketplaces default to `auto_update: true` — git pull on every sync.
- Fix state reader to prefer user-scope install entries over older project-scope entries in `installed_plugins.json`
- Fix export orphan detection to handle non-standard marketplace directory layouts (superpowers-marketplace, yamlscript, replicated-plugins, single-plugin repos)
- Fix sync to atomically disable plugins installed with `enabled: false` in the Clewfile

## Test plan

- [x] Unit tests pass (`make test-unit`)
- [x] UAT on this workstation: `clew export`, `clew diff`, `clew sync` all clean
- [x] UAT on alice.local: `clew sync` converged, `clew diff` shows 0 to add after sync
- [x] UAT on studio.local: fresh machine, 28/30 plugins installed (2 failures expected — local path marketplaces whose paths don't exist on that machine)
- [x] `gtm@replicated-plugins` disabled correctly on first install across all machines
- [x] User-scope preference verified: project-scope entries no longer shadow reinstalled user-scope entries